### PR TITLE
Add entrypoint to ensure folders in mounted volumes

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -79,3 +79,6 @@ RUN mkdir -p \
     /var/log \
     /var/run \
     /var/www/html
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/v3.1/entrypoint.sh
+++ b/v3.1/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+mkdir -p "${MODSEC_AUDIT_STORAGE}" \
+         "${MODSEC_DATA_DIR}" \
+         "${MODSEC_TMP_DIR}" \
+         "${MODSEC_UPLOAD_DIR}"
+
+exec /docker-entrypoint.sh "$@"


### PR DESCRIPTION
Adds an entrypoint script to ensure some folders exist when volumes are mounted over those locations.

Note that the script calls the base image's entrypoint script. It's a pain. :worried: 