### PR TITLE
Add upstream command (stripped out by Docker)

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -81,4 +81,6 @@ RUN mkdir -p \
     /var/www/html
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ["apachectl", "-D", "FOREGROUND"]


### PR DESCRIPTION
We need to re-add the upstream CMD in our Dockerfile.

Why? Docker assumes that we want change the entrypoint + command logic when we override the ENTRYPOINT, and clears the CMD silently. (Hint: Verify this with `docker inspect vshn/modsecurity`)