### PR TITLE
Add non-logging /healthz endpoint

### DIFF
--- a/v3.1/sites-available/000-default.conf
+++ b/v3.1/sites-available/000-default.conf
@@ -6,8 +6,14 @@
 
   LogLevel ${APACHE_LOGLEVEL}
   ErrorLog ${APACHE_ERRORLOG}
-  CustomLog ${APACHE_ACCESSLOG}
+  CustomLog ${APACHE_ACCESSLOG} env=!nologging
   CustomLog ${APACHE_PERFLOG}
+
+  <Location "/healthz">
+    SetEnv nologging
+    SetHandler server-status
+    ProxyPass !
+  </Location>
 
   RemoteIPHeader X-Forwarded-For
   RemoteIPInternalProxy ${REMOTEIP_INT_PROXY}


### PR DESCRIPTION
These changes

- add a `/healthz` endpoint to the Apache configuration,
- which does not log any access to it.

The endpoint is implemented using Apache's [mod_status](https://httpd.apache.org/docs/2.4/mod/mod_status.html) module. Note that that page also mentions having `mod_status` loaded (which is the default in the base image) is considered a security risk.