### PR TITLE
Add ignore rule for /healthz to keep log clean

### DIFF
--- a/v3.1/custom-rules/after-crs.dist/cleanlogs.conf
+++ b/v3.1/custom-rules/after-crs.dist/cleanlogs.conf
@@ -1,0 +1,3 @@
+# === Exempt frequent well-known requests from logging, e.g. health checks (ids: TBD - TBD)
+
+SecRule REQUEST_URI "@beginsWith /healthz" "phase:2,id:40000,pass,nolog"


### PR DESCRIPTION
Adds an ignore rule to avoid logging requests in the audit.log on the `/healthz` endpoint to the default configuration.

Without this rule any access to `/healthz` is logged in the Apache `ErrorLog` and `/var/log/modsecurity/audit.log` (as currently the case).

Thanks to @franbuehler to pair programming! :medal_sports: 