### PR TITLE
Stop processing rules on /healthz URI path

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -8,7 +8,7 @@ ENV APACHE_RUN_USER=www-data \
     BACKEND=http://localhost:8080 \
     APACHE_TIMEOUT=5 \
     APACHE_LOGLEVEL=notice \
-    APACHE_ERRORLOG='"|/usr/bin/stdbuf -i 0 -o 0 /opt/transform-alert-message.awk"' \
+    APACHE_ERRORLOG="|/usr/bin/stdbuf -i0 -o0 /opt/transform-alert-message.awk" \
     APACHE_ACCESSLOG="/dev/stdout extendedjson" \
     APACHE_PERFLOG="/dev/stdout perflogjson env=write_perflog" \
     MODSEC_AUDIT_LOG=/var/log/modsecurity/audit.log \

--- a/v3.1/custom-rules/after-crs.dist/cleanlogs.conf
+++ b/v3.1/custom-rules/after-crs.dist/cleanlogs.conf
@@ -1,3 +1,3 @@
-# === Exempt frequent well-known requests from logging, e.g. health checks (ids: TBD - TBD)
+# === Exempt frequent well-known requests from logging, e.g. health checks (ids: 40000 - 40100)
 
-SecRule REQUEST_URI "@beginsWith /healthz" "phase:2,id:40000,pass,nolog"
+SecRule REQUEST_FILENAME "@streq /healthz" "phase:2,id:40000,nolog,allow"


### PR DESCRIPTION
We need to use `allow` instead of `pass` to make ModSecurity stop processing.