### PR TITLE
Fix permission issues for /etc/modsecurity.d

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -68,6 +68,7 @@ RUN mkdir -p \
     /var/log/modsecurity/audit \
  && chgrp -R 0 \
     /etc/apache2 \
+    /etc/modsecurity.d \
     /opt/modsecurity \
     /tmp/modsecurity \
     /var/lock/apache2 \
@@ -76,6 +77,7 @@ RUN mkdir -p \
     /var/www/html \
  && chmod -R g=u \
     /etc/apache2 \
+    /etc/modsecurity.d \
     /opt/modsecurity \
     /tmp/modsecurity \
     /var/lock/apache2 \


### PR DESCRIPTION
Since we upgraded the base image last week bringing up a pod on OpenShift fails:
```
Could not open configuration file /etc/modsecurity.d/modsecurity.conf: Permission denied
```
Some configuration files in `/etc/modsecurity.d/` have permissions 700 and all of them belong to `root`. Since OpenShift uses an arbitrary (non-root) user Apache can access those files.

The fix applies the [typical OpenShift user permission](https://docs.okd.io/latest/creating_images/guidelines.html#openshift-specific-guidelines) also to the `/etc/modsecurity.d/` folder.