### PR TITLE
Add generic infrastructure exclusion rule for OpenShift

### DIFF
--- a/v3.1/custom-rules/after-crs.dist/infrastructure.conf
+++ b/v3.1/custom-rules/after-crs.dist/infrastructure.conf
@@ -1,0 +1,4 @@
+# Make compatible with Forwarded headers set by OpenShift 3 routers
+# ModSec Rule Exclusion: 920274 : Invalid character in request headers
+# (outside of very strict set) (severity: CRITICAL) PL4
+SecRuleUpdateTargetById 920274 "!REQUEST_HEADERS:Forwarded"


### PR DESCRIPTION
OpenShift 3 routers add a specific Forwarded request header that triggers 920274 on PL4.
This PR excludes the mentioned request header from the rule 920274.