### PR TITLE
Comment out two rules regarding the geoLookupDB

### DIFF
--- a/v3.1/custom-rules/before-crs.dist/geolocation.conf
+++ b/v3.1/custom-rules/before-crs.dist/geolocation.conf
@@ -1,3 +1,3 @@
 # Perform geolocation
-SecRule REMOTE_ADDR "@geoLookup" "id:90200,phase:1,pass,t:none,nolog"
-SecRule GEO:COUNTRY_CODE "@unconditionalMatch" "id:90201,phase:1,pass,t:none,nolog,setenv:GEOIP_COUNTRY_CODE=%{MATCHED_VAR}"
+# SecRule REMOTE_ADDR "@geoLookup" "id:90200,phase:1,pass,t:none,nolog"
+# SecRule GEO:COUNTRY_CODE "@unconditionalMatch" "id:90201,phase:1,pass,t:none,nolog,setenv:GEOIP_COUNTRY_CODE=%{MATCHED_VAR}"


### PR DESCRIPTION
In order to reduce the log output regarding a missing LookupDB we commented out the two rules which are affected