### PR TITLE
Add metrics supports

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -12,6 +12,8 @@ ENV APACHE_RUN_USER=www-data \
     APACHE_ACCESSLOG='/dev/stdout extendedjson' \
     APACHE_PERFLOG='/dev/stdout perflogjson env=write_perflog' \
     APACHE_METRICSLOG='/dev/null combined' \
+    APACHE_METRICS_DENY_FROM='All' \
+    APACHE_METRICS_ALLOW_FROM='127.0.0.0/255.0.0.0 ::1/128' \
     MODSEC_AUDIT_LOG=/var/log/modsecurity/audit.log \
     MODSEC_AUDIT_STORAGE=/var/log/modsecurity/audit/ \
     MODSEC_DEBUG_LOG=/dev/null \

--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -11,6 +11,7 @@ ENV APACHE_RUN_USER=www-data \
     APACHE_ERRORLOG='"|/usr/bin/stdbuf -i0 -o0 /opt/transform-alert-message.awk"' \
     APACHE_ACCESSLOG='/dev/stdout extendedjson' \
     APACHE_PERFLOG='/dev/stdout perflogjson env=write_perflog' \
+    APACHE_METRICSLOG='/dev/null combined' \
     MODSEC_AUDIT_LOG=/var/log/modsecurity/audit.log \
     MODSEC_AUDIT_STORAGE=/var/log/modsecurity/audit/ \
     MODSEC_DEBUG_LOG=/dev/null \

--- a/v3.1/sites-available/000-default.conf
+++ b/v3.1/sites-available/000-default.conf
@@ -19,6 +19,9 @@
   </Location>
   <Location "/metrics/apache">
     SetEnv nologging
+    Order deny,allow
+    Deny from ${APACHE_METRICS_DENY_FROM}
+    Allow from ${APACHE_METRICS_ALLOW_FROM}
     ProxyPass !
     SetHandler server-status
   </Location>

--- a/v3.1/sites-available/000-default.conf
+++ b/v3.1/sites-available/000-default.conf
@@ -8,6 +8,7 @@
   # ErrorLog ${APACHE_ERRORLOG}
   CustomLog ${APACHE_ACCESSLOG} "env=!nologging"
   CustomLog ${APACHE_PERFLOG}
+  CustomLog ${APACHE_METRICSLOG} "env=!nologging"
 
   <Location "/healthz">
     SetEnv nologging
@@ -15,6 +16,11 @@
     RewriteRule .* - [R=200,L]
     ErrorDocument 200 "OK"
     ProxyPass !
+  </Location>
+  <Location "/metrics/apache">
+    SetEnv nologging
+    ProxyPass !
+    SetHandler server-status
   </Location>
 
   RemoteIPHeader X-Forwarded-For


### PR DESCRIPTION
1) Add mod_status support for use with apache_exporter
2) Add another access log file location for parsing metrics 
from the access log.

Open for discussions if another CustomLog directive with "/dev/null" is a good approach. Haven't found a better solution.