### PR TITLE
Add rule to ignore requests from localhost

### DIFF
--- a/v3.1/custom-rules/before-crs.dist/cleanlogs.conf
+++ b/v3.1/custom-rules/before-crs.dist/cleanlogs.conf
@@ -8,3 +8,8 @@
 # - allow request
 # - don't write an audit log for the request
 SecRule REMOTE_ADDR "^10\.1\.\d+\.1$" "phase:1,id:40000,nolog,allow,ctl:auditEngine=Off"
+
+# Ignore requests coming from localhost. This is useful if there are request issued via Shell or
+# from a sidecar that provide limited or no customization in the request headers (e.g. Apache exporter).
+SecRule REMOTE_ADDR "@ipMatch 127.0.0.1" "phase:1,id:40001,nolog,allow,ctl:auditEngine=Off"
+SecRule REMOTE_ADDR "@ipMatch ::1" "phase:1,id:40002,nolog,allow,ctl:auditEngine=Off"


### PR DESCRIPTION
Suppresses log entries that are coming from localhost,
e.g. a sidecar like the Apache exporter.

I'm not sure what `ctl:ruleRemoveById=920300` does, please indicate whether this is correct.