### PR TITLE
Add support for clamav virus scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ For the default values look at the `Dockerfile`.
 
 For the default values look at the `Dockerfile`.
 
+### CLAMAV
+* CLAMD_SERVER (Default: 127.0.0.1)
+  * host/ip of server running clamd
+* CLAMD_PORT (Default: 3310)
+  * port on which clamd is listening
+
 ### Custom rules
 
 Mount your custom rules at `/opt/modsecurity/rules/before-crs/` to load them

--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -42,7 +42,9 @@ ENV APACHE_RUN_USER=www-data \
     PARANOIA=1 \
     ANOMALY_INBOUND=1000 \
     ANOMALY_OUTBOUND=1000 \
-    HTTPD_MAX_REQUEST_WORKERS=250
+    HTTPD_MAX_REQUEST_WORKERS=250 \
+    CLAMD_SERVER=127.0.0.1 \
+    CLAMD_PORT=3310
 
 COPY ports.conf /etc/apache2/
 COPY sites-available /etc/apache2/sites-available
@@ -50,9 +52,9 @@ COPY conf-available /etc/apache2/conf-available
 COPY modsecurity.d /etc/apache2/modsecurity.d
 COPY custom-rules/before-crs.dist /opt/modsecurity/rules/before-crs.dist
 COPY custom-rules/after-crs.dist /opt/modsecurity/rules/after-crs.dist
-COPY transform-alert-message.awk /opt/
+COPY transform-alert-message.awk virus-check.pl /opt/
 
-# fix hack of upstream image, enable confs and modules
+# fix hack of upstream image, enable confs and modules, install clamdscan
 RUN mv -v /etc/apache2/conf-enabled/security.conf /etc/apache2/conf-available/ \
  && sed -i /etc/apache2/apache2.conf \
    -e 's/^LogLevel .*$/LogLevel ${APACHE_LOGLEVEL}/' \
@@ -65,7 +67,9 @@ RUN mv -v /etc/apache2/conf-enabled/security.conf /etc/apache2/conf-available/ \
  && a2enconf logging security \
  && a2enmod headers remoteip rewrite \
  && apt-get update \
- && apt-get install -y gawk
+ && apt-get install -y gawk clamdscan gettext-base
+
+COPY clamd.conf.template /etc/clamav/
 
 RUN mkdir /tmp/geoip \
  && cd /tmp/geoip \
@@ -101,6 +105,7 @@ RUN mkdir -p \
     /var/www/html \
  && chmod -R g=u \
     /etc/apache2 \
+    /etc/clamav \
     /etc/modsecurity.d \
     /opt/modsecurity \
     /tmp/modsecurity \

--- a/v3.1/clamd.conf.template
+++ b/v3.1/clamd.conf.template
@@ -1,0 +1,5 @@
+LogFile /dev/stdout
+LogTime yes
+
+TCPSocket ${CLAMD_PORT}
+TCPAddr ${CLAMD_SERVER}

--- a/v3.1/entrypoint.sh
+++ b/v3.1/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+envsubst < /etc/clamav/clamd.conf.template > /etc/clamav/clamd.conf
+
 mkdir -p "${MODSEC_AUDIT_STORAGE}" \
          "${MODSEC_DATA_DIR}" \
          "${MODSEC_TMP_DIR}" \

--- a/v3.1/virus-check.pl
+++ b/v3.1/virus-check.pl
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+#---------------------------------------------------
+#
+# virus-check.pl
+#
+# ModSec virus check script used as a wrapper for
+# clamAV
+#
+#---------------------------------------------------
+# Author:       Christian Folini, netnea.com
+# Last Update:  2015-06-23
+#---------------------------------------------------
+
+#---------------------------------------------------
+# Initialisation
+#---------------------------------------------------
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+
+my $do_log = 1;
+my $logfile = "/tmp/virus-check.log";
+
+my $BIN = "clamdscan";
+
+if ($#ARGV != 0) {
+    print "Usage: virus-check.pl <filename>\n";
+    exit;
+}
+
+my ($myfile) = shift @ARGV;
+my $filesize = -s $myfile;
+
+if ( $do_log ) { writelog("Initialisation for scanning of file $myfile ($filesize bytes)")} ;
+
+my $result = "";
+my $status = "";
+my $output = "";
+
+#---------------------------------------------------
+# Sub-Functions
+#---------------------------------------------------
+
+sub writelog {  
+   # We open/close the logfile after every time as there might be 
+   # multiple instances attempting to write.
+   # If there is a collision we simply ignore the failure and move on
+
+   my ($logitem) = @_;
+   my $date = strftime "%Y-%m-%d %H:%M:%S", localtime;
+   
+   if ( open(LOG, ">>", $logfile)) {
+   	print LOG "$date : pid $$ : $logitem\n";
+   	close(LOG);
+   } else {
+   	print "Problem writing logfile $logfile. Ignoring.\n";
+   }
+
+}
+
+#---------------------------------------------------
+# clamAV execution
+#---------------------------------------------------
+
+
+if ( $do_log ) { writelog("Calling clamAV ($BIN) ...")} ;
+
+$result = `$BIN --stdout $myfile`;
+
+my $myresult = $result;
+
+$myresult =~ s/\n/ | /g;
+if ( $do_log ) { writelog("ClamAV returned result : $myresult")} ;
+
+$result =~ m/^(.+)/;
+$status = $1;
+
+if ( $do_log ) { writelog("Extracted status : $status")} ;
+
+$output = "0 Error parsing clamAV output : $1";
+
+#---------------------------------------------------
+# Interpretation of clamAV output
+#---------------------------------------------------
+
+if ($status =~ m/: OK$/) {
+    $output = "1 clamAV OK";
+}
+elsif ($status =~ m/: Empty file\.?$/) {
+    $output = "1 empty file";
+}
+elsif ($status =~ m/: (.+) ERROR$/) {
+    $output = "0 clamAV: $1";
+}
+elsif ($status =~ m/: (.+) FOUND$/) {
+    $output = "0 clamAV: $1";
+}
+
+#---------------------------------------------------
+# Bailing out
+#---------------------------------------------------
+
+if ( $do_log ) { writelog("Return value : $output")} ;
+
+print "$output\n";
+
+if ( $do_log ) { writelog("Bailing out")} ;
+


### PR DESCRIPTION
It's now possible to scan uploaded files for viruses via modsecurity.
The script `/opt/virus-check.pl` will scan any uploaded file for
viruses using clamav. The script requires a remote clamd server
listening on port 3310. The clamd server can be specified using the
ENV variables `$CLAMD_SERVER` and `$CLAMD_PORT`.