### PR TITLE
Configure ClamAV scanning logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ For the default values look at the `Dockerfile`.
   * host/ip of server running clamd
 * CLAMD_PORT (Default: `3310`)
   * port on which clamd is listening
+* CLAMD_DEBUG_LOG (Default: `off`)
+  * whether ClamAV scanning should log debug messages
 
 ### Custom rules
 

--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -48,7 +48,8 @@ ENV APACHE_RUN_USER=www-data \
     ANOMALY_OUTBOUND=1000 \
     HTTPD_MAX_REQUEST_WORKERS=250 \
     CLAMD_SERVER=127.0.0.1 \
-    CLAMD_PORT=3310
+    CLAMD_PORT=3310 \
+    CLAMD_DEBUG_LOG=off
 
 COPY ports.conf /etc/apache2/
 COPY sites-available /etc/apache2/sites-available

--- a/v3.1/virus-check.pl
+++ b/v3.1/virus-check.pl
@@ -19,8 +19,8 @@ use strict;
 use warnings;
 use POSIX qw(strftime);
 
-my $do_log = 1;
-my $logfile = "/tmp/virus-check.log";
+my $do_log = $ENV{"CLAMD_DEBUG_LOG"} eq "on" ? 1 : 0;
+my $logfile = "/dev/stdout";
 
 my $BIN = "clamdscan";
 


### PR DESCRIPTION
Log ClamAV scanning debug logs to stdout and make it configurable.