### PR TITLE
Include crs-setup rules *after* before-crs rules

### DIFF
--- a/v3.1/modsecurity.d/include.conf
+++ b/v3.1/modsecurity.d/include.conf
@@ -1,9 +1,9 @@
 # Allow custom rules to be specified in:
 # /opt/modsecurity/rules/{before,after}-crs/*.conf
 
-Include modsecurity.d/owasp-crs/crs-setup.conf
 Include /opt/modsecurity/rules/before-crs.dist/*.conf
 IncludeOptional /opt/modsecurity/rules/before-crs/*.conf
+Include modsecurity.d/owasp-crs/crs-setup.conf
 Include modsecurity.d/owasp-crs/rules/*.conf
 Include /opt/modsecurity/rules/after-crs.dist/*.conf
 IncludeOptional /opt/modsecurity/rules/after-crs/*.conf


### PR DESCRIPTION
Makes sure we can apply (exclusion) rule _before_ any rules of the CRS are included.

**Relates to:** [FILO-255](https://control.vshn.net/tickets/FILO-255)