### PR TITLE
Move custom before-crs rules as first import

### DIFF
--- a/v3.1/modsecurity.d/include.conf
+++ b/v3.1/modsecurity.d/include.conf
@@ -1,8 +1,8 @@
 # Allow custom rules to be specified in:
 # /opt/modsecurity/rules/{before,after}-crs/*.conf
 
-Include /opt/modsecurity/rules/before-crs.dist/*.conf
 IncludeOptional /opt/modsecurity/rules/before-crs/*.conf
+Include /opt/modsecurity/rules/before-crs.dist/*.conf
 Include modsecurity.d/owasp-crs/crs-setup.conf
 Include modsecurity.d/owasp-crs/rules/*.conf
 Include /opt/modsecurity/rules/after-crs.dist/*.conf


### PR DESCRIPTION
This enables the configuration of recommended rules.