### PR TITLE
Add timing information for metrics log

### DIFF
--- a/v3.1/conf-available/logging.conf
+++ b/v3.1/conf-available/logging.conf
@@ -2,7 +2,7 @@
 
 ErrorLogFormat          "[%{cu}t] [%-m:%-l] %-a %-L %M"
 
-LogFormat               "%a %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \
+LogFormat               "%a %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O %I %D \
 \"%{Referer}i\" \"%{User-Agent}i\"" combined
 
 LogFormat "{ \"apache-access\": { \"remoteHost\":\"%a\", \"countryCode\":\"%{GEOIP_COUNTRY_CODE}e\", \"username\":\"%u\", \"timestamp\":\"%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t\", \"requestLine\":\"%r\", \"status\":%>s, \"responseBodySize\":%B, \


### PR DESCRIPTION
`%O` and `%I` provide the timing metrics. `%D` replaces `%b` to log the full size of the response (including headers).