### PR TITLE
Make SSL VHost configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ FROM vshn/modsecurity:3.1
 ENV PARANOIA=1 \
     ANOMALY_INBOUND=500 \
     ANOMALY_OUTBOUND=400 \
-    PORT=8000 \
+    HTTP_PORT=8000 \
     BACKEND=http://facade-svc:9000
 
 VOLUME /opt/modsecurity/rules/before-crs
@@ -88,8 +88,10 @@ There are a variety of environment variables available to configure the image.
   * inbound anomaly score threshold; start with 1000 and try to bring it down to 5
 * ANOMALY_OUTBOUND (Default: `1000`)
   * outbound anomaly score threshold; start with 1000 and try to bring it down to 4
-* PORT (Default: `8080`)
-  * Port the Apache process should listen on
+* HTTP_PORT (Default: `8080`)
+  * Port the Apache process should listen on for HTTP
+* SSL_PORT (Default: `8443`)
+  * Port the Apache process should listen on for HTTPS
 * BACKEND
   * The IP/URL of the service which should be secured by ModSecurity.
 * BACKEND_WS

--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -4,7 +4,8 @@ ENV APACHE_RUN_USER=www-data \
     APACHE_RUN_GROUP=root \
     SERVER_ADMIN=root@localhost \
     SERVER_NAME=localhost \
-    PORT=8080 \
+    HTTP_PORT=8080 \
+    SSL_PORT=8443 \
     BACKEND=http://localhost:8080 \
     BACKEND_WS=ws://localhost:8080 \
     APACHE_TIMEOUT=5 \
@@ -74,7 +75,9 @@ RUN mv -v /etc/apache2/conf-enabled/security.conf /etc/apache2/conf-available/ \
    -e 's/MaxRequestWorkers .*/MaxRequestWorkers ${HTTPD_MAX_REQUEST_WORKERS}/' \
  && ln -sfv /dev/stdout /var/log/apache2/access.log \
  && ln -sfv /dev/stderr /var/log/apache2/error.log \
- && a2enconf logging security \
+ && a2enconf \
+      logging \
+      security \
  && a2enmod \
       headers \
       proxy_wstunnel \
@@ -90,7 +93,7 @@ COPY clamd.conf.template /etc/clamav/
 RUN mkdir /tmp/geoip \
  && cd /tmp/geoip \
  && apt-get update \
- && apt-get install -y --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       clamdscan \
       curl \
       gawk \

--- a/v3.1/ports.conf
+++ b/v3.1/ports.conf
@@ -1,4 +1,5 @@
-# Make sure you keep the values in this file aligned with
-# the VirtualHost in: sites-available/000-default.conf
+# Make sure you keep the values in this file aligned with the VirtualHosts
+# in sites-available/, 000-default.conf and default-ssl.conf
 
-Listen ${PORT}
+Listen ${HTTP_PORT}
+Listen ${SSL_PORT} https

--- a/v3.1/sites-available/000-default.conf
+++ b/v3.1/sites-available/000-default.conf
@@ -1,4 +1,4 @@
-<Virtualhost *:${PORT}>
+<Virtualhost *:${HTTP_PORT}>
   ServerName ${SERVER_NAME}
   ServerAdmin ${SERVER_ADMIN}
 
@@ -33,21 +33,20 @@
   RequestHeader set X-Real-IP %{REMOTE_ADDR}s
   RequestHeader set X-Unique-ID %{UNIQUE_ID}e
 
+  RewriteEngine on
+  RewriteCond %{HTTP:Upgrade} websocket [NC]
+  RewriteCond %{HTTP:Connection} upgrade [NC]
+  RewriteRule .* "${BACKEND_WS}%{REQUEST_URI}" [P]
+
   SSLProxyEngine ${PROXY_SSL}
   SSLProxyVerify ${PROXY_SSL_VERIFY}
   SSLProxyCheckPeerName ${PROXY_SSL_CHECK_PEER_NAME}
   SSLProxyCACertificateFile ${PROXY_SSL_CA_CERT}
 
   ProxyRequests off
-  ProxyPreserveHost ${PROXY_PRESERVE_HOST}
   ProxyErrorOverride on
-
+  ProxyPreserveHost ${PROXY_PRESERVE_HOST}
   ProxyTimeout ${PROXY_TIMEOUT}
-
-  RewriteEngine on
-  RewriteCond %{HTTP:Upgrade} websocket [NC]
-  RewriteCond %{HTTP:Connection} upgrade [NC]
-  RewriteRule .* "${BACKEND_WS}%{REQUEST_URI}" [P]
 
   ProxyPass / ${BACKEND}/ disablereuse=on
   ProxyPassReverse / ${BACKEND}/

--- a/v3.1/sites-available/default-ssl.conf
+++ b/v3.1/sites-available/default-ssl.conf
@@ -1,0 +1,134 @@
+<IfModule mod_ssl.c>
+	<VirtualHost _default_:443>
+		ServerAdmin webmaster@localhost
+
+		DocumentRoot /var/www/html
+
+		# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+		# error, crit, alert, emerg.
+		# It is also possible to configure the loglevel for particular
+		# modules, e.g.
+		#LogLevel info ssl:warn
+
+		ErrorLog ${APACHE_LOG_DIR}/error.log
+		CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+		# For most configuration files from conf-available/, which are
+		# enabled or disabled at a global level, it is possible to
+		# include a line for only one particular virtual host. For example the
+		# following line enables the CGI configuration for this host only
+		# after it has been globally disabled with "a2disconf".
+		#Include conf-available/serve-cgi-bin.conf
+
+		#   SSL Engine Switch:
+		#   Enable/Disable SSL for this virtual host.
+		SSLEngine on
+
+		#   A self-signed (snakeoil) certificate can be created by installing
+		#   the ssl-cert package. See
+		#   /usr/share/doc/apache2/README.Debian.gz for more info.
+		#   If both key and certificate are stored in the same file, only the
+		#   SSLCertificateFile directive is needed.
+		SSLCertificateFile	/etc/ssl/certs/ssl-cert-snakeoil.pem
+		SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+		#   Server Certificate Chain:
+		#   Point SSLCertificateChainFile at a file containing the
+		#   concatenation of PEM encoded CA certificates which form the
+		#   certificate chain for the server certificate. Alternatively
+		#   the referenced file can be the same as SSLCertificateFile
+		#   when the CA certificates are directly appended to the server
+		#   certificate for convinience.
+		#SSLCertificateChainFile /etc/apache2/ssl.crt/server-ca.crt
+
+		#   Certificate Authority (CA):
+		#   Set the CA certificate verification path where to find CA
+		#   certificates for client authentication or alternatively one
+		#   huge file containing all of them (file must be PEM encoded)
+		#   Note: Inside SSLCACertificatePath you need hash symlinks
+		#		 to point to the certificate files. Use the provided
+		#		 Makefile to update the hash symlinks after changes.
+		#SSLCACertificatePath /etc/ssl/certs/
+		#SSLCACertificateFile /etc/apache2/ssl.crt/ca-bundle.crt
+
+		#   Certificate Revocation Lists (CRL):
+		#   Set the CA revocation path where to find CA CRLs for client
+		#   authentication or alternatively one huge file containing all
+		#   of them (file must be PEM encoded)
+		#   Note: Inside SSLCARevocationPath you need hash symlinks
+		#		 to point to the certificate files. Use the provided
+		#		 Makefile to update the hash symlinks after changes.
+		#SSLCARevocationPath /etc/apache2/ssl.crl/
+		#SSLCARevocationFile /etc/apache2/ssl.crl/ca-bundle.crl
+
+		#   Client Authentication (Type):
+		#   Client certificate verification type and depth.  Types are
+		#   none, optional, require and optional_no_ca.  Depth is a
+		#   number which specifies how deeply to verify the certificate
+		#   issuer chain before deciding the certificate is not valid.
+		#SSLVerifyClient require
+		#SSLVerifyDepth  10
+
+		#   SSL Engine Options:
+		#   Set various options for the SSL engine.
+		#   o FakeBasicAuth:
+		#	 Translate the client X.509 into a Basic Authorisation.  This means that
+		#	 the standard Auth/DBMAuth methods can be used for access control.  The
+		#	 user name is the `one line' version of the client's X.509 certificate.
+		#	 Note that no password is obtained from the user. Every entry in the user
+		#	 file needs this password: `xxj31ZMTZzkVA'.
+		#   o ExportCertData:
+		#	 This exports two additional environment variables: SSL_CLIENT_CERT and
+		#	 SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+		#	 server (always existing) and the client (only existing when client
+		#	 authentication is used). This can be used to import the certificates
+		#	 into CGI scripts.
+		#   o StdEnvVars:
+		#	 This exports the standard SSL/TLS related `SSL_*' environment variables.
+		#	 Per default this exportation is switched off for performance reasons,
+		#	 because the extraction step is an expensive operation and is usually
+		#	 useless for serving static content. So one usually enables the
+		#	 exportation for CGI and SSI requests only.
+		#   o OptRenegotiate:
+		#	 This enables optimized SSL connection renegotiation handling when SSL
+		#	 directives are used in per-directory context.
+		#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+		<FilesMatch "\.(cgi|shtml|phtml|php)$">
+				SSLOptions +StdEnvVars
+		</FilesMatch>
+		<Directory /usr/lib/cgi-bin>
+				SSLOptions +StdEnvVars
+		</Directory>
+
+		#   SSL Protocol Adjustments:
+		#   The safe and default but still SSL/TLS standard compliant shutdown
+		#   approach is that mod_ssl sends the close notify alert but doesn't wait for
+		#   the close notify alert from client. When you need a different shutdown
+		#   approach you can use one of the following variables:
+		#   o ssl-unclean-shutdown:
+		#	 This forces an unclean shutdown when the connection is closed, i.e. no
+		#	 SSL close notify alert is send or allowed to received.  This violates
+		#	 the SSL/TLS standard but is needed for some brain-dead browsers. Use
+		#	 this when you receive I/O errors because of the standard approach where
+		#	 mod_ssl sends the close notify alert.
+		#   o ssl-accurate-shutdown:
+		#	 This forces an accurate shutdown when the connection is closed, i.e. a
+		#	 SSL close notify alert is send and mod_ssl waits for the close notify
+		#	 alert of the client. This is 100% SSL/TLS standard compliant, but in
+		#	 practice often causes hanging connections with brain-dead browsers. Use
+		#	 this only for browsers where you know that their SSL implementation
+		#	 works correctly.
+		#   Notice: Most problems of broken clients are also related to the HTTP
+		#   keep-alive facility, so you usually additionally want to disable
+		#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+		#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+		#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+		#   "force-response-1.0" for this.
+		# BrowserMatch "MSIE [2-6]" \
+		#		nokeepalive ssl-unclean-shutdown \
+		#		downgrade-1.0 force-response-1.0
+
+	</VirtualHost>
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/v3.1/sites-available/default-ssl.conf
+++ b/v3.1/sites-available/default-ssl.conf
@@ -1,134 +1,29 @@
 <IfModule mod_ssl.c>
-	<VirtualHost _default_:443>
-		ServerAdmin webmaster@localhost
+	<VirtualHost _default_:${SSL_PORT}>
+		ServerName ${SERVER_NAME}
+		ServerAdmin ${SERVER_ADMIN}
 
-		DocumentRoot /var/www/html
+		LogLevel ${APACHE_LOGLEVEL}
+		ErrorLog ${APACHE_ERRORLOG}
+		CustomLog ${APACHE_ACCESSLOG} "env=!nologging"
 
-		# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-		# error, crit, alert, emerg.
-		# It is also possible to configure the loglevel for particular
-		# modules, e.g.
-		#LogLevel info ssl:warn
-
-		ErrorLog ${APACHE_LOG_DIR}/error.log
-		CustomLog ${APACHE_LOG_DIR}/access.log combined
-
-		# For most configuration files from conf-available/, which are
-		# enabled or disabled at a global level, it is possible to
-		# include a line for only one particular virtual host. For example the
-		# following line enables the CGI configuration for this host only
-		# after it has been globally disabled with "a2disconf".
-		#Include conf-available/serve-cgi-bin.conf
-
-		#   SSL Engine Switch:
-		#   Enable/Disable SSL for this virtual host.
 		SSLEngine on
 
-		#   A self-signed (snakeoil) certificate can be created by installing
-		#   the ssl-cert package. See
-		#   /usr/share/doc/apache2/README.Debian.gz for more info.
-		#   If both key and certificate are stored in the same file, only the
-		#   SSLCertificateFile directive is needed.
 		SSLCertificateFile	/etc/ssl/certs/ssl-cert-snakeoil.pem
 		SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 
-		#   Server Certificate Chain:
-		#   Point SSLCertificateChainFile at a file containing the
-		#   concatenation of PEM encoded CA certificates which form the
-		#   certificate chain for the server certificate. Alternatively
-		#   the referenced file can be the same as SSLCertificateFile
-		#   when the CA certificates are directly appended to the server
-		#   certificate for convinience.
-		#SSLCertificateChainFile /etc/apache2/ssl.crt/server-ca.crt
+		SSLProxyEngine ${PROXY_SSL}
+		SSLProxyVerify ${PROXY_SSL_VERIFY}
+		SSLProxyCheckPeerName ${PROXY_SSL_CHECK_PEER_NAME}
+		SSLProxyCACertificateFile ${PROXY_SSL_CA_CERT}
 
-		#   Certificate Authority (CA):
-		#   Set the CA certificate verification path where to find CA
-		#   certificates for client authentication or alternatively one
-		#   huge file containing all of them (file must be PEM encoded)
-		#   Note: Inside SSLCACertificatePath you need hash symlinks
-		#		 to point to the certificate files. Use the provided
-		#		 Makefile to update the hash symlinks after changes.
-		#SSLCACertificatePath /etc/ssl/certs/
-		#SSLCACertificateFile /etc/apache2/ssl.crt/ca-bundle.crt
+		ProxyRequests off
+		ProxyErrorOverride on
+		ProxyPreserveHost ${PROXY_PRESERVE_HOST}
+		ProxyTimeout ${PROXY_TIMEOUT}
 
-		#   Certificate Revocation Lists (CRL):
-		#   Set the CA revocation path where to find CA CRLs for client
-		#   authentication or alternatively one huge file containing all
-		#   of them (file must be PEM encoded)
-		#   Note: Inside SSLCARevocationPath you need hash symlinks
-		#		 to point to the certificate files. Use the provided
-		#		 Makefile to update the hash symlinks after changes.
-		#SSLCARevocationPath /etc/apache2/ssl.crl/
-		#SSLCARevocationFile /etc/apache2/ssl.crl/ca-bundle.crl
-
-		#   Client Authentication (Type):
-		#   Client certificate verification type and depth.  Types are
-		#   none, optional, require and optional_no_ca.  Depth is a
-		#   number which specifies how deeply to verify the certificate
-		#   issuer chain before deciding the certificate is not valid.
-		#SSLVerifyClient require
-		#SSLVerifyDepth  10
-
-		#   SSL Engine Options:
-		#   Set various options for the SSL engine.
-		#   o FakeBasicAuth:
-		#	 Translate the client X.509 into a Basic Authorisation.  This means that
-		#	 the standard Auth/DBMAuth methods can be used for access control.  The
-		#	 user name is the `one line' version of the client's X.509 certificate.
-		#	 Note that no password is obtained from the user. Every entry in the user
-		#	 file needs this password: `xxj31ZMTZzkVA'.
-		#   o ExportCertData:
-		#	 This exports two additional environment variables: SSL_CLIENT_CERT and
-		#	 SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
-		#	 server (always existing) and the client (only existing when client
-		#	 authentication is used). This can be used to import the certificates
-		#	 into CGI scripts.
-		#   o StdEnvVars:
-		#	 This exports the standard SSL/TLS related `SSL_*' environment variables.
-		#	 Per default this exportation is switched off for performance reasons,
-		#	 because the extraction step is an expensive operation and is usually
-		#	 useless for serving static content. So one usually enables the
-		#	 exportation for CGI and SSI requests only.
-		#   o OptRenegotiate:
-		#	 This enables optimized SSL connection renegotiation handling when SSL
-		#	 directives are used in per-directory context.
-		#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
-		<FilesMatch "\.(cgi|shtml|phtml|php)$">
-				SSLOptions +StdEnvVars
-		</FilesMatch>
-		<Directory /usr/lib/cgi-bin>
-				SSLOptions +StdEnvVars
-		</Directory>
-
-		#   SSL Protocol Adjustments:
-		#   The safe and default but still SSL/TLS standard compliant shutdown
-		#   approach is that mod_ssl sends the close notify alert but doesn't wait for
-		#   the close notify alert from client. When you need a different shutdown
-		#   approach you can use one of the following variables:
-		#   o ssl-unclean-shutdown:
-		#	 This forces an unclean shutdown when the connection is closed, i.e. no
-		#	 SSL close notify alert is send or allowed to received.  This violates
-		#	 the SSL/TLS standard but is needed for some brain-dead browsers. Use
-		#	 this when you receive I/O errors because of the standard approach where
-		#	 mod_ssl sends the close notify alert.
-		#   o ssl-accurate-shutdown:
-		#	 This forces an accurate shutdown when the connection is closed, i.e. a
-		#	 SSL close notify alert is send and mod_ssl waits for the close notify
-		#	 alert of the client. This is 100% SSL/TLS standard compliant, but in
-		#	 practice often causes hanging connections with brain-dead browsers. Use
-		#	 this only for browsers where you know that their SSL implementation
-		#	 works correctly.
-		#   Notice: Most problems of broken clients are also related to the HTTP
-		#   keep-alive facility, so you usually additionally want to disable
-		#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
-		#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
-		#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
-		#   "force-response-1.0" for this.
-		# BrowserMatch "MSIE [2-6]" \
-		#		nokeepalive ssl-unclean-shutdown \
-		#		downgrade-1.0 force-response-1.0
+		ProxyPass / ${BACKEND}/ disablereuse=on
+		ProxyPassReverse / ${BACKEND}/
 
 	</VirtualHost>
 </IfModule>
-
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Replicates many of the HTTP VHost settings in a SSL VHost configuration to allow serving HTTPS.

Note that by default this will server the `index.html` in the default `DocumentRoot`. The `PROXY_SSL` environment variable needs to be set to `on` to override this behavior.