### PR TITLE
Add correct permissions for owasp-crs folder

### DIFF
--- a/v3.3/Dockerfile
+++ b/v3.3/Dockerfile
@@ -105,6 +105,7 @@ RUN mkdir -p \
     /etc/clamav \
     /etc/modsecurity.d \
     /opt/modsecurity \
+    /opt/owasp-crs \
     /usr/local/apache2 \
     /tmp/modsecurity \
     /var/lock/apache2 \
@@ -114,6 +115,7 @@ RUN mkdir -p \
     /etc/clamav \
     /etc/modsecurity.d \
     /opt/modsecurity \
+    /opt/owasp-crs \
     /usr/local/apache2 \
     /tmp/modsecurity \
     /var/lock/apache2 \


### PR DESCRIPTION
We need write permissions on the owasp-crs folder for modsecurity to
work properly.