### PR TITLE
fix(security): Update to version 3.3.2

### DIFF
--- a/v3.3/Dockerfile
+++ b/v3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/owasp/modsecurity-crs:3.3-apache
+FROM docker.io/owasp/modsecurity-crs:v3.3.2-apache
 
 ENV APACHE_RUN_USER=www-data \
     APACHE_RUN_GROUP=root \


### PR DESCRIPTION
A security fix released in CVE-2021-35368 has been published and this
image is updated to the latest version that fixes the issues in that CVE