### PR TITLE
Integrate modsecurity-crs' new tag strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,16 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["digest"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["owasp/modsecurity-crs"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<compatibility>[a-z\\-]+)-(?<build>\\d+)$"
+    },
+    {
+      "matchUpdateTypes": ["patch", "digest"],
       "automerge": true
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
The new tags contain the build date of the Docker image. This makes it incompatible with the default versioning strategy of Renovate.

The current setup is based on the CRS minor version and automerging patch updates is therefore acceptable.

Renovate treats build number updates as patch updates.