### PR TITLE
deps: Ensure Renovate config matches ModSec image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["owasp/modsecurity-crs"],
+      "matchPackagePatterns": ["^(docker\.io/)?owasp/modsecurity-crs$"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<compatibility>[a-z\\-]+)-(?<build>\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})$"
     },
     {


### PR DESCRIPTION
The dockerfile was updated to use the fully qualified path for the docker image some time ago.