### PR TITLE
Fix parsing issues for PCRE error messages

### DIFF
--- a/v3.3/transform-alert-message.awk
+++ b/v3.3/transform-alert-message.awk
@@ -87,6 +87,10 @@ BEGIN {
 	Description = ""
 	json_out = ""
 
+	# This substition is done for PCRE error messages. For some reason the different sections of the
+	# error message, are not separated with a space between the closing and opening square brackets.
+	# Adding a space in those cases allows `awk` to properly split the different sections
+	gsub(/\]\[/,"] [");
 	for (i = 1; i <= NF; i++) {
 		# read values
 		switch (FN) {


### PR DESCRIPTION
The PCRE error messages have slightly different format (no whitespace between the different fields inclosed in square brackets)

This leads to parsing issues in the awk script, as it doesn't recognize the fields correctly anymore due to the missing whitespace.

By adjusting the input so that between a closing and opening square braken there always is a whitespace, we ensure that the fields are correctly distinguished.

Resolves: #45 