### PR TITLE
Set initial value for in- and outbound anomaly score

### DIFF
--- a/v3.3/custom-rules/before-crs.dist/baseconfig.conf
+++ b/v3.3/custom-rules/before-crs.dist/baseconfig.conf
@@ -5,7 +5,9 @@ SecAction "id:900110,phase:1,pass,nolog,\
   setvar:tx.outbound_anomaly_score_threshold=${ANOMALY_OUTBOUND}"
 
 SecAction "id:900120,phase:1,pass,nolog,\
-  setvar:tx.paranoia_level=${PARANOIA}"
+  setvar:tx.paranoia_level=${PARANOIA},\
+  setvar:tx.anomaly_score=0,\
+  setvar:tx.outbound_anomaly_score=0"
 
 SecAction "id:900200,phase:1,pass,nolog,setvar:'tx.allowed_methods=${MODSEC_ALLOWED_METHODS}'"
 SecAction "id:900220,phase:1,pass,nolog,setvar:'tx.allowed_request_content_type=${MODSEC_ALLOWED_CONTENT}'"

--- a/v3.3/httpd-logging.conf
+++ b/v3.3/httpd-logging.conf
@@ -6,9 +6,9 @@ LogFormat               "%a %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %
 \"%{Referer}i\" \"%{User-Agent}i\"" combined
 
 LogFormat "{ \"apache-access\": { \"remoteHost\":\"%a\", \"username\":\"%u\", \"timestamp\":\"%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t\", \"requestLine\":\"%r\", \"status\":%>s, \"responseBodySize\":%B, \
-\"referer\":\"%{Referer}i\", \"userAgent\":\"%{User-Agent}i\", \"serverName\":\"%v\", \"serverIP\":\"%A\",\"serverPort\":%p, \"handler\":\"%R\", \"workerRoute\":\"%{BALANCER_WORKER_ROUTE}e\", \"tcpStatus\":\"%X\", \"cookie\":\"%{cookie}n\", \
-\"uniqueID\":\"%{UNIQUE_ID}e\", \"requestBytes\":%I, \"responseBytes\":%O,\"compressionRatio\":\"%{ratio}n%%\", \
-\"requestDuration\":%D,\"modsecTimeIn\":%{ModSecTimeIn}e, \"applicationTime\":%{ApplicationTime}e, \"modsecTimeOut\":%{ModSecTimeOut}e, \
+\"referer\":\"%{Referer}i\", \"userAgent\":\"%{User-Agent}i\", \"serverName\":\"%v\", \"serverIP\":\"%A\", \"serverPort\":%p, \"handler\":\"%R\", \"workerRoute\":\"%{BALANCER_WORKER_ROUTE}e\", \"tcpStatus\":\"%X\", \"cookie\":\"%{cookie}n\", \
+\"uniqueID\":\"%{UNIQUE_ID}e\", \"requestBytes\":%I, \"responseBytes\":%O, \"compressionRatio\":\"%{ratio}n%%\", \
+\"requestDuration\":%D, \"modsecTimeIn\":%{ModSecTimeIn}e, \"applicationTime\":%{ApplicationTime}e, \"modsecTimeOut\":%{ModSecTimeOut}e, \
 \"modsecAnomalyScoreIn\":%{ModSecAnomalyScoreIn}e, \"modsecAnomalyScoreThresholdIn\":%{ModSecAnomalyScoreThresholdIn}e, \"modsecAnomalyScoreOut\":%{ModSecAnomalyScoreOut}e, \"modsecAnomalyScoreThresholdOut\":%{ModSecAnomalyScoreThresholdOut}e, \"modsecParanoiaLevel\":%{ModSecParanoiaLevel}e } }" extendedjson
 
 LogFormat "%a %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \

--- a/v3.3/modsecurity.d/include.conf
+++ b/v3.3/modsecurity.d/include.conf
@@ -1,8 +1,8 @@
 # Allow custom rules to be specified in:
 # /opt/modsecurity/rules/{before,after}-crs/*.conf
 
-IncludeOptional /opt/modsecurity/rules/before-crs/*.conf
 Include /opt/modsecurity/rules/before-crs.dist/*.conf
+IncludeOptional /opt/modsecurity/rules/before-crs/*.conf
 Include /etc/modsecurity.d/owasp-crs/crs-setup.conf
 Include /etc/modsecurity.d/owasp-crs/rules/*.conf
 Include /opt/modsecurity/rules/after-crs.dist/*.conf


### PR DESCRIPTION
The anomaly score variables are not set to a specific value at the beginning. This can lead to an empty field in the access-log if a rule is triggered with a `deny`. The reason is, that a deny will abort any further rule evaluation and therefore also the anomaly score calculation. Initializing the scores to 0 at the beginning eliminates this issue.