### PR TITLE
Fix awk script parsing of ERRORLOG for key uniqueID

### DIFF
--- a/transform-alert-message.awk
+++ b/transform-alert-message.awk
@@ -107,7 +107,8 @@ BEGIN {
 		# tag
 		case "hostname":  Hostname	= substr($i, 2, length($i) - 3); FN = ""; break
 		case "uri":       Uri	        = substr($i, 2, length($i) - 3); FN = ""; break
-		case "unique_id": UniqueID 	= substr($i, 2, length($i) - 3); FN = ""; break
+		# This needs to remove 1 char more since it's the last entry and ends in "], instead of "]
+		case "unique_id": UniqueID 	= substr($i, 2, length($i) - 4); FN = ""; break
 		case "msg":
 			if ( substr($i, 1, 1) == "\"" ) {
 				Msg = substr($i, 2, length($i) - 1)


### PR DESCRIPTION
Parsing for uniqueID in awk script for ERRORLOG was broken.
This lead to the resulting json being invalid and therefore unable to be parsed by indexer.
Example:
Raw output:
```
[Tue Sep 17 08: 05: 27.183579 2024
] [security2:error
] [pid 21:tid 50
] [client 172.23.0.1: 37142
] [client 172.23.0.1
] ModSecurity: Warning. Pattern match "(?i)\\\\b(?:(?:alter|(?:(?:cre|trunc|upd)at|renam)e|de(?:lete|sc)|(?:inser|selec)t|load)[\\\\s\\\\x0b]+(?:char|group_concat|load_file)\\\\b[\\\\s\\\\x0b]*\\\\(?|end[\\\\s\\\\x0b]*?\\\\);)|[\\\\s\\\\x0b\\\\(]load_file[\\\\s\\\\x0b]*?\\\\(|[\\"'`
][\\\\s\\\\x0b
]+regexp[^0-9A-Z_a-z
]|[\\"'0-9A- ..." at ARGS:custname. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"
] [line "488"
] [id "942360"
] [msg "Detects concatenated basic SQL injection and SQLLFI attempts"
] [data "Matched Data: ;DROP TABLE found within ARGS:custname: ;DROP TABLE users"
] [severity "CRITICAL"
] [ver "OWASP_CRS/4.5.0"
] [tag "modsecurity"
] [tag "application-multi"
] [tag "language-multi"
] [tag "platform-multi"
] [tag "attack-sqli"
] [tag "paranoia-level/1"
] [tag "OWASP_CRS"
] [tag "capec/1000/152/248/66"
] [tag "PCI/6.5.2"
] [hostname "localhost"
] [uri "/post"
] [unique_id "Zuk4RzhZik-uyUXpxVi8aQAAAAA"
], referer: http: //localhost:8080/forms/post
```
Currently transforms to:
```
{
  "modsec-alert": {
    "description": "ModSecurity: Warning. Unconditional match in SecAction. referer: http://localhost:8080/forms/post",
    "id": 980170,
    "client": "172.23.0.1",
    "hostname": "localhost",
    "uri": "/post",
    "uniqueID": "Zuk3_s5usqh0-UBcN9cBvgAAAAA"","msg": "Anomaly Scores: (Inbound Scores: blocking=10, detection=10, per_pl=10-0-0-0, threshold=1000) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=1000) - (SQLI=10, XSS=0, RFI=0, LFI=0, RCE=0, PHPI=0, HTTP=0, SESS=0, COMBINED_SCORE=10)","data": "","severity": "","tags": ["modsecurity", "reporting", "OWASP_CRS", "platform-multi", "attack-sqli", "paranoia-level/1", "OWASP_CRS", "capec/1000/152/248/66", "PCI/6.5.2"],"file": "/etc/modsecurity.d/owasp-crs/rules/RESPONSE-980-CORRELATION.conf","line": 98,"rev": "","ver": "OWASP_CRS/4.5.0","maturity": "","rule_template": "# ModSec Rule Exclusion: 980170 : Anomaly Scores: (Inbound Scores: blocking=10, detection=10, per_pl=10-0-0-0, threshold=1000) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=1000) - (SQLI=10, XSS=0, RFI=0, LFI=0, RCE=0, PHPI=0, HTTP=0, SESS=0, COMBINED_SCORE=10) (severity:  )"} }
```
Issue is the leftover " at the end of the uniqueID value.