### PR TITLE
Adjust log output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/coreruleset/modsecurity-crs:4.5.0-apache-alpine-202407300107
 
 ENV ACCESSLOG=/dev/stdout \
-    ERRORLOG='"|/usr/bin/stdbuf -i0 -o0 /opt/transform-alert-message.awk"' \
+    ERRORLOG='"|/usr/bin/stdbuf -i0 -oL /opt/transform-alert-message.awk"' \
     PERFLOG=/dev/stdout \
     LOGLEVEL=notice \
     TIMEOUT=5 \

--- a/transform-alert-message.awk
+++ b/transform-alert-message.awk
@@ -274,10 +274,10 @@ BEGIN {
 		Ver = ""
 		Maturity = ""
 
-		print json_out
+		print json_out "\n"
 
 	} else {
-		print $0
+		print $0 "\n"
 	}
 }
 


### PR DESCRIPTION
Adjust log output in order to avoid race condition in which separate log outputs get written to same line rendering them unable to be parsed by log collectors.