### PR TITLE
Add mod_qos with env-driven config, IP whitelist, and proxy test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@ CODEOWNERS
 Containerfile
 README.md
 compose.yaml
+tests
 renovate.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,12 @@ jobs:
       - name: Verify
         run: |
           [ $(docker inspect apache --format='{{.State.Running}}') = 'true' ]
+
+  mod_qos-test:
+    name: mod_qos proxy test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Run mod_qos proxy test
+        run: bash tests/test_proxy.sh

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,22 @@
-FROM ghcr.io/coreruleset/modsecurity-crs:4.27.0-apache-202606261106@sha256:9ea0cf58be42b59555d12b06227e3515b05eafa53c09bd9109ce9a107e811be6
+FROM ghcr.io/coreruleset/modsecurity-crs:4.26.0-apache-202605200705@sha256:28264667ad2acb83213282ebb0583c8ab8bdddc044787bd53958a80217b2b4b1 AS qos-builder
+USER root
+ARG MOD_QOS_VERSION=11.79
+ARG MOD_QOS_SHA256=314a60638be42203cd0ed6ed1fe22085c082919545561387db4e7cb35594d755
+RUN set -x && \
+    mkdir -p /output && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential libpcre2-dev libssl-dev libapr1-dev libaprutil1-dev ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl --cacert /etc/ssl/certs/ca-certificates.crt -fsSL \
+        -o /output/mod_qos-${MOD_QOS_VERSION}.tar.gz \
+        "https://downloads.sourceforge.net/project/mod-qos/mod_qos-${MOD_QOS_VERSION}.tar.gz" && \
+    echo "${MOD_QOS_SHA256}  /output/mod_qos-${MOD_QOS_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf /output/mod_qos-${MOD_QOS_VERSION}.tar.gz -C /output
+WORKDIR /output/mod_qos-${MOD_QOS_VERSION}/apache2
+RUN /usr/local/apache2/bin/apxs -i -c mod_qos.c -lcrypto -lpcre2-8
+
+FROM ghcr.io/coreruleset/modsecurity-crs:4.26.0-apache-202605200705@sha256:28264667ad2acb83213282ebb0583c8ab8bdddc044787bd53958a80217b2b4b1
 
 ENV ACCESSLOG=/dev/stdout \
     ERRORLOG='"|/usr/bin/stdbuf -i0 -oL /opt/transform-alert-message.awk"' \
@@ -23,7 +41,26 @@ ENV ACCESSLOG=/dev/stdout \
     MODSEC_RESP_BODY_LIMIT=500000000 \
     CLAMD_DEBUG_LOG=off \
     # Use the default docker subnet as the default \
-    HEALTHZ_CIDRS=172.18.0.0/24
+    HEALTHZ_CIDRS=172.18.0.0/24 \
+    MOD_QOS_ENABLED=disabled \
+    MOD_QOS_LOGENV="" \
+    QOS_SRV_MAX_CONN="" \
+    QOS_SRV_MAX_CONN_PER_IP="" \
+    QOS_SRV_MAX_CONN_CLOSE="" \
+    QOS_SRV_MIN_DATA_RATE="" \
+    QOS_LOC_REQUEST_LIMIT_DEFAULT="" \
+    QOS_CLIENT_EVENT_PER_SEC_LIMIT="" \
+    QOS_CLIENT_EVENT_LIMIT_COUNT="60 60" \
+    QOS_CLIENT_EVENT_BLOCK_COUNT="" \
+    QOS_BLOCK_LOCATION="/" \
+    QOS_ALLOW_LOCATION="/healthz" \
+    QOS_BLOCK_EVENTS=1 \
+    QOS_REQUEST_HEADER_FILTER="" \
+    QOS_LIMIT_REQUEST_BODY="" \
+    QOS_CLIENT_IP_FROM_HEADER="" \
+    QOS_EXCLUDE_IP="" \
+    QOS_DEFAULT_CONF_FILE="conf/extra/mod_qos/qos-rules.conf" \
+    QOS_CONF_FILE="conf/extra/mod_qos/qos-rules.conf"
 
 USER root
 
@@ -43,6 +80,7 @@ RUN set -x && \
     sed -i '/<VirtualHost \*:${SSL_PORT}>/,/<\/VirtualHost>/d' /usr/local/apache2/conf/extra/httpd-vhosts.conf && \
     sed -i '/Include .*httpd-ssl.conf/d' /usr/local/apache2/conf/httpd.conf && \
     sed -i '/^\/usr\/local\/bin\/generate-certificate/d' /docker-entrypoint.sh && \
+	sed -i '/# Virtual hosts/i\IncludeOptional /usr/local/apache2/conf/extra/mod_qos/qos-active.conf' /usr/local/apache2/conf/httpd.conf && \
 	#Make sure the ProxyPass setting for error-pages is included prior to the ones in vhost settings \
 	sed -i '/httpd-modsecurity.conf/d' /usr/local/apache2/conf/httpd.conf && \
 	sed -i '/# Virtual hosts/i\Include conf/extra/httpd-modsecurity.conf' /usr/local/apache2/conf/httpd.conf && \
@@ -59,12 +97,18 @@ RUN chgrp -R 0 /opt/owasp-crs && \
     chmod -R g+rwX /opt/owasp-crs
 RUN chgrp -R 0 /usr/local/apache2/logs && \
     chmod -R g+rwX /usr/local/apache2/logs
+RUN mkdir -p /usr/local/apache2/conf/extra/mod_qos/ && \
+    chgrp 0 /usr/local/apache2/conf/extra/mod_qos/ && \
+    chmod g+rwX /usr/local/apache2/conf/extra/mod_qos/
 
 # Customized configuration files
 COPY opt/* /opt/
 COPY clamd-config/* /etc/clamav/
 COPY apache-config/* /usr/local/apache2/conf/extra/
 COPY modsecurity.d/setup.conf /etc/modsecurity.d/setup.conf
+
+COPY --from=qos-builder /usr/local/apache2/modules/mod_qos.so /usr/local/apache2/modules/mod_qos.so
+COPY httpd-foreground /usr/local/bin/httpd-foreground
 
 # Custom ModSecurity rules
 COPY ./custom-rules/before-crs.dist /opt/modsecurity/rules/before-crs.dist

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Don't forget to `git push --tags` afterwards!
 
 Most aspects can be configured using environment variables.
 For a full list of supported environment variables, see the [upstream documentation][upstream].
-We use the Apache Alpine image.
+We use the Apache Debian image.
 
 ### Extra configuration variables
 
@@ -61,6 +61,71 @@ We use the Apache Alpine image.
   This should usually be set to your Kubernetes host subnet range.
   Multiple CIDR ranges can be specified.
   Example: `1.2.3.4/24,5.6.7.8/24`
+
+### mod_qos
+
+This image ships the [mod_qos](https://mod-qos.sourceforge.net/) module, compiled from source in a multi-stage build. Only the `mod_qos.so` is copied into the runtime image.
+
+mod_qos is **not loaded by default** (`MOD_QOS_ENABLED=disabled`). Set `MOD_QOS_ENABLED=on` to activate it. All options are configurable via environment variables:
+
+| Variable                         | mod_qos directive                                                                                                   | Default          |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `MOD_QOS_ENABLED`                | loads the module if set to `on`                                                                                     | `disabled`       |
+| `QOS_SRV_MAX_CONN`               | [`QS_SrvMaxConn`](https://mod-qos.sourceforge.net/#QS_SrvMaxConn)                                                   | empty (disabled) |
+| `QOS_SRV_MAX_CONN_PER_IP`        | [`QS_SrvMaxConnPerIP`](https://mod-qos.sourceforge.net/#QS_SrvMaxConnPerIP)                                         | empty (disabled) |
+| `QOS_SRV_MAX_CONN_CLOSE`         | [`QS_SrvMaxConnClose`](https://mod-qos.sourceforge.net/#QS_SrvMaxConnClose)                                         | empty (disabled) |
+| `QOS_SRV_MIN_DATA_RATE`          | [`QS_SrvMinDataRate`](https://mod-qos.sourceforge.net/#QS_SrvMinDataRate)                                           | empty (disabled) |
+| `QOS_LOC_REQUEST_LIMIT_DEFAULT`  | [`QS_LocRequestLimitDefault`](https://mod-qos.sourceforge.net/#QS_LocRequestLimitDefault)                           | empty (disabled) |
+| `QOS_CLIENT_EVENT_PER_SEC_LIMIT` | [`QS_ClientEventPerSecLimit`](https://mod-qos.sourceforge.net/#QS_ClientEventPerSecLimit)                           | empty (disabled) |
+| `QOS_CLIENT_EVENT_LIMIT_COUNT`   | [`QS_ClientEventLimitCount`](https://mod-qos.sourceforge.net/#QS_ClientEventLimitCount)                             | `60 60`         |
+| `QOS_CLIENT_EVENT_BLOCK_COUNT`   | [`QS_ClientEventBlockCount`](https://mod-qos.sourceforge.net/#QS_ClientEventBlockCount)                             | empty (disabled) |
+| `QOS_REQUEST_HEADER_FILTER`      | [`QS_RequestHeaderFilter`](https://mod-qos.sourceforge.net/#QS_RequestHeaderFilter)                                 | empty (disabled) |
+| `QOS_LIMIT_REQUEST_BODY`         | [`QS_LimitRequestBody`](https://mod-qos.sourceforge.net/#QS_LimitRequestBody)                                       | empty (disabled) |
+| `QOS_CLIENT_IP_FROM_HEADER`      | [`QS_ClientIpFromHeader`](https://mod-qos.sourceforge.net/#QS_ClientIpFromHeader)                                   | empty (disabled) |
+| `QOS_EXCLUDE_IP`                 | [`QS_SrvMaxConnExcludeIP`](https://mod-qos.sourceforge.net/#QS_SrvMaxConnExcludeIP) (one per comma-separated entry) | empty (disabled) |
+| `QOS_BLOCK_LOCATION`             | sets `QS_Limit` via `SetEnvIf` (see below)                                                                          | `/`              |
+| `QOS_ALLOW_LOCATION`             | unsets `QS_Limit` via `SetEnvIf` (see below)                                                                        | `/healthz`       |
+
+Defaults other than `MOD_QOS_ENABLED` only take effect once mod_qos is enabled (`MOD_QOS_ENABLED=on`). `HEALTHZ_CIDRS` IPs are automatically whitelisted (first two octets of each CIDR entry). For per-path rules, use `QOS_BLOCK_LOCATION` (see below).
+
+#### `QOS_BLOCK_LOCATION` — paths to rate-limit
+
+`QOS_BLOCK_LOCATION="/api,/login"` — comma-separated paths. Each matching request increments the shared `QS_Limit` counter (weight `QOS_BLOCK_EVENTS`, default 1). The threshold and window come from `QOS_CLIENT_EVENT_LIMIT_COUNT` (e.g. `200 60` = block after 200 events within 60s per client IP). A single `/` rate-limits every location.
+
+All listed paths share one counter and one threshold: a client that trips the limit on one path is blocked on all of them (mod_qos checks `counter >= threshold` on every request regardless of which path filled the counter). Use `QOS_ALLOW_LOCATION` for paths that must not increment the counter.
+
+The generated `SetEnvIf` setters are written to `qos-active.conf`.
+
+#### `QOS_ALLOW_LOCATION` — never-count paths
+
+`QOS_ALLOW_LOCATION="/health,/ready"` — comma-separated paths that must **not increment** the `QS_Limit` counter, so healthchecks from a separate monitor IP never get throttled and never burn a client's quota. The auto-generated rules emit `SetEnvIf Request_URI ^<path> !QS_Limit` per allow-path, overriding the block-path increment (last-match-wins).
+
+**Note (by-design caveat):** `mod_qos` evaluates `counter >= threshold` on every request regardless of which path filled the counter, so an already-blocked client's request to an allow-path is **also** blocked. This is the chosen trade-off: there is no rate-limit bypass (an attacker cannot un-block themselves by interleaving an allow-path), at the cost that a flood-abusing client's `/health` is also throttled. For unthrottactable healthchecks, run them from a whitelisted source IP (`QOS_EXCLUDE_IP`/`HEALTHZ_CIDRS`) or an address outside any limit's window.
+
+The IP whitelist (`QOS_EXCLUDE_IP` / `HEALTHZ_CIDRS`) exempts source IPs from the `QS_Limit` counter via `SetEnvIf Remote_Addr ^<prefix> !QS_Limit` (one rule per prefix, covers all block paths automatically).
+
+#### `QOS_CLIENT_IP_FROM_HEADER` behind mod_remoteip
+
+The base image loads `mod_remoteip` with `RemoteIPHeader X-Forwarded-For`, so `mod_remoteip` resolves the real client IP from `X-Forwarded-For` into `r->useragent_ip` and **strips `X-Forwarded-For`** from the request headers before `mod_qos` runs. Therefore:
+
+- Do **not** set `QOS_CLIENT_IP_FROM_HEADER=X-Forwarded-For` behind mod_remoteip — `mod_qos` won't find the (stripped) header, logs `mod_qos(069)` and falls back to the proxy/pod IP, collapsing all clients into one rate-limit bucket.
+- Set `QOS_CLIENT_IP_FROM_HEADER=#USERAGENT_IP` (recommended) to make `mod_qos` read `mod_remoteip`'s resolved client IP directly. This produces zero `069` errors (even for the container's own healthcheck) and gives per-real-client rate-limit counters.
+- `X-Real-IP` works only while an upstream proxy sets it and it survives `mod_remoteip` (mod_remoteip only strips its configured `RemoteIPHeader`); not guaranteed on every platform.
+
+When `QOS_CLIENT_IP_FROM_HEADER` is a `#`-prefixed pseudo-header (such as `#USERAGENT_IP`), the auto-generated whitelist uses `SetEnvIf Remote_Addr ^<prefix> !QS_Limit` (matching `r->useragent_ip`) so `QOS_EXCLUDE_IP` and `HEALTHZ_CIDRS` exempt the real client IPs from `QS_ClientEventLimitCount`.
+
+`QOS_BLOCK_LOCATION` defaults to `/` (rate-limit every location). Set `QOS_ALLOW_LOCATION` to exclude paths such as healthchecks, or run healthchecks from a whitelisted source IP.
+
+### Bot-protection logging
+
+mod_qos logs to the field `botProtection`. \
+See <https://mod-qos.sourceforge.net/#accesslog> under `mod_qos_ev`
+
+- `D;` (denied/blocked) when the request was blocked
+- `S;` If the request was marked as VIP.
+- `-` when no mod_qos event occurred or when mod_qos is not enabled.
+
+The letters can be combined, for example `S;D;` means both denied and skipped.
 
 ## License
 

--- a/apache-config/vshn-logging.conf
+++ b/apache-config/vshn-logging.conf
@@ -8,7 +8,7 @@ LogFormat "{ \"apacheAccess\": { \"remoteHost\":\"%a\", \"username\":\"%u\", \"t
 \"referer\":\"%{Referer}i\", \"userAgent\":\"%{User-Agent}i\", \"serverName\":\"%v\", \"serverIP\":\"%A\", \"serverPort\":%p, \"handler\":\"%R\", \"workerRoute\":\"%{BALANCER_WORKER_ROUTE}e\", \"tcpStatus\":\"%X\", \"cookie\":\"%{cookie}n\", \
 \"uniqueID\":\"%{UNIQUE_ID}e\", \"requestBytes\":%I, \"responseBytes\":%O, \"compressionRatio\":\"%{ratio}n%%\", \
 \"requestDuration\":%D, \"modsecTimeIn\":%{ModSecTimeIn}e, \"applicationTime\":%{ApplicationTime}e, \"modsecTimeOut\":%{ModSecTimeOut}e, \
-\"modsecAnomalyScoreIn\":%{ModSecAnomalyScoreIn}e, \"modsecAnomalyScoreThresholdIn\":\"%{ModSecAnomalyScoreThresholdIn}e\", \"modsecAnomalyScoreOut\":%{ModSecAnomalyScoreOut}e, \"modsecAnomalyScoreThresholdOut\":\"%{ModSecAnomalyScoreThresholdOut}e\", \"modsecParanoiaLevel\":%{ModSecParanoiaLevel}e } }" \
+\"modsecAnomalyScoreIn\":%{ModSecAnomalyScoreIn}e, \"modsecAnomalyScoreThresholdIn\":\"%{ModSecAnomalyScoreThresholdIn}e\", \"modsecAnomalyScoreOut\":%{ModSecAnomalyScoreOut}e, \"modsecAnomalyScoreThresholdOut\":\"%{ModSecAnomalyScoreThresholdOut}e\", \"modsecParanoiaLevel\":%{ModSecParanoiaLevel}e, \"botProtection\":\"%{mod_qos_ev}e\" } }" \
 extendedjson
 
 CustomLog ${ACCESSLOG} extendedjson "env=!nologging"

--- a/httpd-foreground
+++ b/httpd-foreground
@@ -1,0 +1,52 @@
+#!/bin/sh
+CONF=/usr/local/apache2/conf/extra/mod_qos/qos-active.conf
+: > "$CONF"
+if [ "$MOD_QOS_ENABLED" = "on" ]; then
+  echo "LoadModule qos_module modules/mod_qos.so" >> "$CONF"
+  [ -n "$QOS_CLIENT_IP_FROM_HEADER" ] && echo "QS_ClientIpFromHeader $QOS_CLIENT_IP_FROM_HEADER" >> "$CONF"
+  for ip in $(echo "$QOS_EXCLUDE_IP" | tr ',' ' '); do
+    [ -n "$ip" ] && echo "QS_SrvMaxConnExcludeIP $ip" >> "$CONF"
+  done
+  for cidr in $(echo "$HEALTHZ_CIDRS" | tr ',' ' '); do
+    prefix=$(echo "$cidr" | cut -d. -f1-2)
+    [ -n "$prefix" ] && echo "QS_SrvMaxConnExcludeIP ${prefix}." >> "$CONF"
+  done
+  [ -n "$MOD_QOS_LOGENV" ] && echo "QS_LogEnv on $MOD_QOS_LOGENV" >> "$CONF"
+  [ -n "$QOS_SRV_MAX_CONN" ] && echo "QS_SrvMaxConn $QOS_SRV_MAX_CONN" >> "$CONF"
+  [ -n "$QOS_SRV_MAX_CONN_PER_IP" ] && echo "QS_SrvMaxConnPerIP $QOS_SRV_MAX_CONN_PER_IP" >> "$CONF"
+  [ -n "$QOS_SRV_MAX_CONN_CLOSE" ] && echo "QS_SrvMaxConnClose $QOS_SRV_MAX_CONN_CLOSE" >> "$CONF"
+  [ -n "$QOS_SRV_MIN_DATA_RATE" ] && echo "QS_SrvMinDataRate $QOS_SRV_MIN_DATA_RATE" >> "$CONF"
+  [ -n "$QOS_LOC_REQUEST_LIMIT_DEFAULT" ] && echo "QS_LocRequestLimitDefault $QOS_LOC_REQUEST_LIMIT_DEFAULT" >> "$CONF"
+  [ -n "$QOS_CLIENT_EVENT_PER_SEC_LIMIT" ] && echo "QS_ClientEventPerSecLimit $QOS_CLIENT_EVENT_PER_SEC_LIMIT" >> "$CONF"
+  [ -n "$QOS_CLIENT_EVENT_LIMIT_COUNT" ] && echo "QS_ClientEventLimitCount $QOS_CLIENT_EVENT_LIMIT_COUNT" >> "$CONF"
+  [ -n "$QOS_CLIENT_EVENT_BLOCK_COUNT" ] && echo "QS_ClientEventBlockCount $QOS_CLIENT_EVENT_BLOCK_COUNT" >> "$CONF"
+  [ -n "$QOS_REQUEST_HEADER_FILTER" ] && echo "QS_RequestHeaderFilter $QOS_REQUEST_HEADER_FILTER" >> "$CONF"
+  [ -n "$QOS_LIMIT_REQUEST_BODY" ] && echo "QS_LimitRequestBody $QOS_LIMIT_REQUEST_BODY" >> "$CONF"
+  if [ -n "$QOS_BLOCK_LOCATION" ]; then
+    for p in $(printf '%s' "$QOS_BLOCK_LOCATION" | tr ',' ' '); do
+      [ -n "$p" ] && echo "SetEnvIf Request_URI ^$p QS_Limit=$QOS_BLOCK_EVENTS" >> "$CONF"
+    done
+  fi
+  echo "IncludeOptional $QOS_CONF_FILE" >> "$CONF"
+  if [ -n "$QOS_ALLOW_LOCATION" ]; then
+    for ap in $(printf '%s' "$QOS_ALLOW_LOCATION" | tr ',' ' '); do
+      [ -n "$ap" ] && echo "SetEnvIf Request_URI ^$ap !QS_Limit" >> "$CONF"
+    done
+  fi
+  hdr="$QOS_CLIENT_IP_FROM_HEADER"
+  [ -z "$hdr" ] && hdr="Remote_Addr"
+  [ "$hdr" = "#USERAGENT_IP" ] && hdr="Remote_Addr"
+  for ip in $(printf '%s' "$QOS_EXCLUDE_IP" | tr ',' ' '); do
+    [ -n "$ip" ] || continue
+    pattern=$(printf '%s' "$ip" | sed 's/\./\\./g')
+    echo "SetEnvIf ${hdr} ^${pattern} !QS_Limit" >> "$CONF"
+  done
+  for cidr in $(printf '%s' "$HEALTHZ_CIDRS" | tr ',' ' '); do
+    prefix=$(printf '%s' "$cidr" | cut -d. -f1-2)
+    [ -n "$prefix" ] || continue
+    pattern=$(printf '%s' "${prefix}." | sed 's/\./\\./g')
+    echo "SetEnvIf ${hdr} ^${pattern} !QS_Limit" >> "$CONF"
+  done
+fi
+rm -f /usr/local/apache2/logs/httpd.pid
+exec httpd -DFOREGROUND "$@"

--- a/tests/compose.proxy.test.yml
+++ b/tests/compose.proxy.test.yml
@@ -1,0 +1,124 @@
+name: modsec-qos-proxy-test
+
+networks:
+  net-a:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.20.0.0/16
+  net-b:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.30.0.0/16
+  net-c:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.40.0.0/16
+  net-d:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.60.0.0/16
+  waf-net:
+    driver: bridge
+
+services:
+  backend:
+    image: "docker.io/sharat87/httpbun:latest@sha256:538a126de2cd4235a8f1f87deb0d002791fd2d4f274033c4050961b6153a0a9a"
+    environment:
+      HTTPBUN_BIND: "0.0.0.0:8080"
+    networks:
+      - waf-net
+
+  waf:
+    build:
+      context: ..
+      dockerfile: Containerfile
+    environment:
+      BACKEND: "http://backend:8080"
+      MOD_QOS_ENABLED: "on"
+      QOS_CLIENT_EVENT_LIMIT_COUNT: "3 60"
+      QOS_CLIENT_IP_FROM_HEADER: "#USERAGENT_IP"
+      REMOTEIP_INT_PROXY: "172.16.0.0/12"
+      QOS_EXCLUDE_IP: "10.20.,10.30."
+      HEALTHZ_CIDRS: "10.40.0.0/24"
+      # shared QS_Limit counter; threshold comes from QOS_CLIENT_EVENT_LIMIT_COUNT.
+      QOS_BLOCK_LOCATION: "/blockslow,/blockfast,/blockme"
+      # allow-path that never burns any limit counter (don't-count semantic).
+      QOS_ALLOW_LOCATION: "/allowalways"
+    user: "10001:0"
+    group_add:
+      - root
+    tmpfs:
+      - "/usr/local/apache2/logs:mode=770"
+    networks:
+      - waf-net
+    depends_on:
+      backend:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/anything"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  reverse-proxy:
+    image: httpd:2.4
+    command: ["httpd-foreground", "-c", "Include conf/reverse-proxy.conf"]
+    volumes:
+      - type: bind
+        source: ./reverse-proxy.conf
+        target: /usr/local/apache2/conf/reverse-proxy.conf
+        read_only: true
+    networks:
+      - net-a
+      - net-b
+      - net-c
+      - net-d
+      - waf-net
+    depends_on:
+      waf:
+        condition: service_healthy
+
+  client-a:
+    image: curlimages/curl:8.14.1
+    entrypoint: ["sleep", "infinity"]
+    networks:
+      net-a:
+        ipv4_address: 10.20.0.11
+    depends_on:
+      reverse-proxy:
+        condition: service_started
+
+  client-b:
+    image: curlimages/curl:8.14.1
+    entrypoint: ["sleep", "infinity"]
+    networks:
+      net-b:
+        ipv4_address: 10.30.0.12
+    depends_on:
+      reverse-proxy:
+        condition: service_started
+
+  client-c:
+    image: curlimages/curl:8.14.1
+    entrypoint: ["sleep", "infinity"]
+    networks:
+      net-c:
+        ipv4_address: 10.40.0.13
+    depends_on:
+      reverse-proxy:
+        condition: service_started
+
+  client-d:
+    image: curlimages/curl:8.14.1
+    entrypoint: ["sleep", "infinity"]
+    networks:
+      net-d:
+        ipv4_address: 10.60.0.14
+    depends_on:
+      reverse-proxy:
+        condition: service_started

--- a/tests/reverse-proxy.conf
+++ b/tests/reverse-proxy.conf
@@ -1,0 +1,11 @@
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule http2_module modules/mod_http2.so
+Listen 8080
+<VirtualHost *:8080>
+  Protocols h2c http/1.1
+  ProxyPreserveHost on
+  ProxyPass / http://waf:8080/ disablereuse=on
+  ProxyPassReverse / http://waf:8080/
+  RequestHeader set X-Real-IP expr=%{REMOTE_ADDR}
+</VirtualHost>

--- a/tests/test_proxy.sh
+++ b/tests/test_proxy.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+COMPOSE=(docker compose -f "${SCRIPT_DIR}/compose.proxy.test.yml" -p modsec-qos-proxy-test)
+WAF="http://reverse-proxy:8080"
+
+code_of() { local c="$1"; shift; "${COMPOSE[@]}" exec -T "$c" curl -s -o /dev/null -w '%{http_code}' "$@" 2>/dev/null || true; }
+ver_of() { local c="$1"; shift; "${COMPOSE[@]}" exec -T "$c" curl -s -o /dev/null -w '%{http_version}' "$@" 2>/dev/null || true; }
+
+assert_burst() {
+  local client="$1" expect="$2" flags="$3" label="$4" path="$5" count="${6:-6}"
+  local codes="" blocked=0 code
+  for i in $(seq 1 "$count"); do
+    code="$(code_of "$client" $flags "${WAF}/${path}")"
+    codes="${codes} ${code}"
+    if [ "${code}" -ge 500 ] 2>/dev/null && [ "${code}" -lt 600 ] 2>/dev/null; then
+      blocked=$((blocked + 1))
+    fi
+  done
+  echo "    ${label} ${client} /${path}:${codes} blocked=${blocked}"
+  if [ "${expect}" = "none" ] && [ "${blocked}" -ne 0 ]; then
+    echo "FAIL: ${client} blocked ${blocked} on /${path} (expected 0, whitelist not working)" >&2; exit 1
+  fi
+  if [ "${expect}" = "some" ] && [ "${blocked}" -le 0 ]; then
+    echo "FAIL: ${client} not blocked on /${path} (expected >=1)" >&2; exit 1
+  fi
+}
+
+assert_allow_no_burn() {
+  local client="$1" allow="$2" blockpath="$3" thr="$4" label="$5" flags="${6:-}"
+  local codes="" code i ablocked=0 bad=0
+  for i in $(seq 1 10); do
+    code="$(code_of "$client" $flags "${WAF}/${allow}")"; codes="${codes} ${code}"
+    [ -z "${code}" -o "${code}" = "000" ] && bad=$((bad + 1))
+    if [ "${code}" -ge 500 ] 2>/dev/null && [ "${code}" -lt 600 ] 2>/dev/null; then ablocked=$((ablocked + 1)); fi
+  done
+  local bpass=0 bcode
+  for i in $(seq 1 "$((thr + 1))"); do
+    bcode="$(code_of "$client" $flags "${WAF}/${blockpath}")"; codes="${codes} ${bcode}"
+    [ -z "${bcode}" -o "${bcode}" = "000" ] && bad=$((bad + 1))
+    if [ "${bcode}" -ge 500 ] 2>/dev/null && [ "${bcode}" -lt 600 ] 2>/dev/null; then break; fi
+    bpass=$((bpass + 1))
+  done
+  echo "    ${label} ${client} /${allow}(10)+/${blockpath}:${codes} blockpass_before=${bpass}"
+  # empty/000 responses mean curl never reached the waf (e.g. a stray "" arg as URL) -> fail loudly
+  [ "$bad" -eq 0 ] || { echo "FAIL: ${client} got ${bad} empty/000 responses on /${allow}+/${blockpath} (test infra broken)" >&2; exit 1; }
+  [ "$ablocked" -eq 0 ] || { echo "FAIL: ${client} allow-path /${allow} blocked ${ablocked} (expected 0)" >&2; exit 1; }
+  if [ "${bpass}" -lt "$((thr - 1))" ]; then
+    echo "FAIL: ${client} only ${bpass} passes on /${blockpath} after /${allow} (allow burned quota, expected >=$((thr-1)))" >&2; exit 1
+  fi
+}
+
+assert_control() {
+  local client="$1" flags="$2" expect_ver="$3" label="$4"
+  local code ver
+  ver="$(ver_of "$client" $flags "${WAF}/anything")"
+  code="$(code_of "$client" $flags "${WAF}/anything")"
+  echo "    ${label} ${client} /anything -> ${code} ver ${ver}"
+  if [ "${expect_ver}" != "any" ] && [ "${ver}" != "${expect_ver}" ]; then
+    echo "FAIL: ${client} protocol ${ver}, expected ${expect_ver}" >&2; exit 1
+  fi
+  if [ "${code:-000}" -lt 200 ] 2>/dev/null || [ "${code:-999}" -ge 400 ] 2>/dev/null; then
+    echo "FAIL: ${client} control ${code} (expected 2xx/3xx)" >&2; exit 1
+  fi
+}
+
+assert_block_logged() {
+  local client_ip="$1" path="$2" label="$3"
+  local log hit
+  log="$("${COMPOSE[@]}" logs --no-log-prefix waf 2>/dev/null || true)"
+  hit="$(printf '%s' "$log" \
+        | grep '"botProtection":"D' \
+        | grep "\"remoteHost\":\"${client_ip}\"" \
+        | grep -E "\"requestLine\":\"[A-Z]+ /${path}( |HTTP/)")"
+  if [ -z "$hit" ]; then
+    echo "FAIL: ${label}: no apacheAccess line with botProtection 'D' for ${client_ip} /${path}" >&2
+    exit 1
+  fi
+  echo "    ${label}: logged bot-protection block for ${client_ip} /${path}"
+}
+
+echo "==> starting stack"
+"${COMPOSE[@]}" up --force-recreate -d --wait --build
+
+# controls MUST run before any burst: mod_qos evaluates `counter >= threshold` every request
+# regardless of which path filled the counter, so an already-blocked client's /anything is also blocked.
+echo "==> HTTP/1.1: controls"
+assert_control client-a "" "1.1" "HTTP/1.1"
+assert_control client-b "" "1.1" "HTTP/1.1"
+assert_control client-c "" "1.1" "HTTP/1.1"
+assert_control client-d "" "1.1" "HTTP/1.1"
+
+echo "==> HTTP/1.1: shared-counter blocking (threshold 3) + allow-location (don't-burn-quota)"
+assert_allow_no_burn client-d allowalways blockslow 3 "HTTP/1.1 allow"
+assert_block_logged 10.60.0.14 blockslow "HTTP/1.1 log"
+assert_burst client-d some "" "HTTP/1.1" blockfast 8
+assert_burst client-d some "" "HTTP/1.1" blockme 6
+
+echo "==> HTTP/1.1: IP whitelist (client-a/b/c)"
+assert_burst client-a none "" "HTTP/1.1" blockslow 6
+assert_burst client-b none "" "HTTP/1.1" blockslow 6
+assert_burst client-c none "" "HTTP/1.1" blockslow 6
+assert_burst client-a none "" "HTTP/1.1" blockfast 8
+assert_burst client-a none "" "HTTP/1.1" blockme 6
+
+# whitelisted clients must never be marked as bot-protection blocks
+neg="$(printf '%s' "$("${COMPOSE[@]}" logs --no-log-prefix waf 2>/dev/null || true)" \
+       | grep '"botProtection":"D' | grep '"remoteHost":"10.20.0.11"' || true)"
+[ -z "$neg" ] || { echo "FAIL: whitelisted client-a (10.20.0.11) was marked botProtection=D" >&2; exit 1; }
+
+echo "==> restarting waf for HTTP/2 tests (also resets mod_qos in-memory counters)"
+"${COMPOSE[@]}" restart waf
+"${COMPOSE[@]}" up -d --wait
+
+echo "==> HTTP/2: controls"
+assert_control client-a "--http2-prior-knowledge" "2" "HTTP/2"
+assert_control client-d "--http2-prior-knowledge" "2" "HTTP/2"
+
+echo "==> HTTP/2: shared-counter blocking + allow"
+assert_allow_no_burn client-d allowalways blockslow 3 "HTTP/2 allow" "--http2-prior-knowledge"
+assert_burst client-a none "--http2-prior-knowledge" "HTTP/2" blockslow 6
+assert_burst client-d some "--http2-prior-knowledge" "HTTP/2" blockslow 6
+assert_burst client-d some "--http2-prior-knowledge" "HTTP/2" blockfast 8
+
+echo "PASS: mod_qos shared-counter blocking, allow-location (don't-count), IP whitelist over HTTP/1.1 and HTTP/2"


### PR DESCRIPTION
The move from Dockerfile to Containerfile was done after the update to 4.27, so we revert the update in this feature branch.

mod_qos 11.79 is compiled from source.

All mod_qos options are configurable via environment variables (QOS_*). 
QOS_EXCLUDE_IP whitelists IP ranges (one QS_SrvMaxConnExcludeIP + SetEnvIf !QS_Limit per comma-separated entry). 
HEALTHZ_CIDRS IPs are auto-whitelisted (first two octets of each CIDR entry).

test_proxy.sh uses docker compose with four networks and fixed client IPs behind an Apache reverse proxy (X-Real-IP injection, HTTP/2 via mod_http2). 
It asserts whitelisted IPs (QOS_EXCLUDE_IP + HEALTHZ_CIDRS) are not blocked on /blockme over HTTP/1.1 and HTTP/2, while non-whitelisted IPs are blocked.